### PR TITLE
Specify path of directory to be created when no settings directory exists

### DIFF
--- a/src/Console/AlgoliaCommand.php
+++ b/src/Console/AlgoliaCommand.php
@@ -20,7 +20,7 @@ class AlgoliaCommand extends Command
 
         // Ensure settings directory exists
         if (! File::exists($this->path)) {
-            File::makeDirectory();
+            File::makeDirectory($this->path);
         }
     }
 


### PR DESCRIPTION
After a fresh install of the package, the required settings directory is supposed to be created if it doesn't already exist. However, a path isn't specified for the directory to be created, and thus an exception is thrown and artisan commands don't work.