### PR TITLE
Correcting path where settings are saved

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Note: Scout allows you to customize the index name with the [`searchableAs()`](h
 
 ### Backing up settings (Project ⬅️ Algolia)
 
-The following command will export all the settings from the `App\Contact`'s index into the `resources/settings/prefix_index_name.json` file.
+The following command will export all the settings from the `App\Contact`'s index into the `resources/algolia-settings/prefix_index_name.json` file.
 
 ```
 php artisan algolia:settings:backup App\Contact
@@ -56,7 +56,7 @@ php artisan algolia:settings:backup App\Contact
 
 ### Pushing settings (Project ➡️ Algolia)
 
-The following command will read all the settings from the `resources/settings/prefix_index_name.json` file and import them into Algolia's index.
+The following command will read all the settings from the `resources/algolia-settings/prefix_index_name.json` file and import them into Algolia's index.
 
 ```
 php artisan algolia:settings:push App\Contact


### PR DESCRIPTION
The documentation has the wrong directory path where settings are saved.