### PR TITLE
Refactor prefix handling, remove prefix from settings content as well

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+* Introduce `IndexName` value object to guard the difference between remote name 
+and local name of an Index
+* Sanitize the index names in the files when not using the `--prefix`-option
+* Expand tests for further coverage 
+
 ## 2.0.0
 
 * Better message in console

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -19,4 +19,7 @@
             <directory suffix=".php">src/</directory>
         </whitelist>
     </filter>
+    <php>
+        <env name="SCOUT_PREFIX" value="testing_"/>
+    </php>
 </phpunit>

--- a/src/Console/AlgoliaCommand.php
+++ b/src/Console/AlgoliaCommand.php
@@ -2,6 +2,7 @@
 
 namespace Algolia\Settings\Console;
 
+use Algolia\Settings\IndexName;
 use Algolia\Settings\IndexResourceRepository;
 use AlgoliaSearch\Client;
 use Illuminate\Console\Command;
@@ -18,9 +19,9 @@ abstract class AlgoliaCommand extends Command
         $this->indexRepository = $indexRepository;
     }
 
-    protected function getIndex($indexName)
+    protected function getIndex(IndexName $indexName)
     {
-        return app(Client::class)->initIndex($indexName);
+        return app(Client::class)->initIndex($indexName->remote());
     }
 
     protected function isClassSearchable($fqn)

--- a/src/IndexName.php
+++ b/src/IndexName.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Algolia\Settings;
+
+final class IndexName
+{
+    /**
+     * @var string
+     */
+    private $remote;
+    /**
+     * @var string
+     */
+    private $local;
+    /**
+     * @var bool
+     */
+    private $usePrefix;
+
+    /**
+     * @param string $remote
+     * @param bool $usePrefix
+     */
+    private function __construct($remote, $usePrefix)
+    {
+        $this->remote    = $remote;
+        $this->usePrefix = $usePrefix;
+    }
+
+    /**
+     * @param string $remoteName
+     * @param bool $usePrefix
+     *
+     * @return static
+     */
+    public static function createFromRemote($remoteName, $usePrefix = true)
+    {
+        return new static($remoteName, $usePrefix);
+    }
+
+    /**
+     * @param string $localName
+     * @param bool $usePrefix
+     *
+     * @return static
+     */
+    public static function createFromLocal($localName, $usePrefix = true)
+    {
+        return new static(
+            config('scout.prefix') . $localName,
+            $usePrefix
+        );
+    }
+
+    /**
+     * @return string
+     */
+    public function local()
+    {
+        if ($this->local) {
+            return $this->local;
+        }
+
+        if ($this->usePrefix) {
+            return $this->local = $this->remote;
+        }
+
+        return $this->local = preg_replace(
+            '/^' . preg_quote(config('scout.prefix'), '/') . '/',
+            '',
+            $this->remote
+        );
+    }
+
+    /**
+     * @return string
+     */
+    public function remote()
+    {
+        return $this->remote;
+    }
+
+    public function usesPrefix()
+    {
+        return $this->usePrefix;
+    }
+
+    /**
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->remote();
+    }
+}

--- a/tests/Algolia/Settings/Console/BackupCommandTest.php
+++ b/tests/Algolia/Settings/Console/BackupCommandTest.php
@@ -63,7 +63,7 @@ final class BackupCommandTest extends TestCase
             $postIndexProphet->initRuleIterator()->willReturn([
                 [
                     'condition'   => [
-                        'pattern'   => '{facet:prefered_contact}',
+                        'pattern'   => '{facet:preferred_contact}',
                         'anchoring' => 'contains',
                         'context'   => 'e-commerce',
                     ],
@@ -147,7 +147,7 @@ final class BackupCommandTest extends TestCase
             $postIndexProphet->initRuleIterator()->willReturn([
                 [
                     'condition'   => [
-                        'pattern'   => '{facet:prefered_contact}',
+                        'pattern'   => '{facet:preferred_contact}',
                         'anchoring' => 'contains',
                         'context'   => 'e-commerce',
                     ],
@@ -179,8 +179,6 @@ final class BackupCommandTest extends TestCase
 
             return $clientProphet->reveal();
         });
-
-        config(['scout.prefix' => 'testing_']);
 
         $this->artisan('algolia:settings:backup', [
             'model' => TestModelWithSearchableTrait::class,

--- a/tests/Algolia/Settings/Console/PushCommandTest.php
+++ b/tests/Algolia/Settings/Console/PushCommandTest.php
@@ -30,7 +30,7 @@ final class PushCommandTest extends TestCase
                             'title'
                         ],
                         'replicas'             => [
-                            'testing_posts_newest'
+                            'posts_newest'
                         ],
                         'customRanking'        => null,
                     ]),
@@ -38,7 +38,7 @@ final class PushCommandTest extends TestCase
                         'searchableAttributes' => [
                             'title'
                         ],
-                        'primary'              => 'testing_posts',
+                        'primary'              => 'posts',
                         'customRanking'        => [
                             'desc(published_at)'
                         ],
@@ -92,7 +92,7 @@ final class PushCommandTest extends TestCase
 
             $postIndexProphet = $this->prophesize(Index::class);
 
-            $clientProphet->initIndex(Argument::any())->willReturn($postIndexProphet->reveal());
+            $clientProphet->initIndex(Argument::containingString('testing_posts'))->willReturn($postIndexProphet->reveal());
 
             return $clientProphet->reveal();
         });
@@ -133,7 +133,7 @@ final class PushCommandTest extends TestCase
                 'customRanking'        => null,
             ])->shouldBeCalled();
 
-            $clientProphet->initIndex(Argument::any())->willReturn($postIndexProphet->reveal());
+            $clientProphet->initIndex(Argument::containingString('testing_posts'))->willReturn($postIndexProphet->reveal());
 
             return $clientProphet->reveal();
         });

--- a/tests/Algolia/Settings/IndexNameTest.php
+++ b/tests/Algolia/Settings/IndexNameTest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Tests\Algolia\Settings;
+
+use Algolia\Settings\IndexName;
+use Algolia\Settings\Tests\TestCase;
+
+final class IndexNameTest extends TestCase
+{
+
+    /**
+     * @dataProvider createFromRemoteDataProvider
+     */
+    public function testCreateFromRemote($remoteName, $usePrefix)
+    {
+        $this->assertInstanceOf(IndexName::class, IndexName::createFromRemote($remoteName, $usePrefix));
+    }
+
+    public function createFromRemoteDataProvider()
+    {
+        return [
+            ['posts', true],
+            ['posts_newest', true],
+            ['testing_posts', true],
+            ['testing_really Any kind of name as an index', true],
+            ['testing_posts', false],
+        ];
+    }
+
+    /**
+     * @dataProvider createReplicaDataProvider
+     */
+    public function testCreateFromLocal($indexName, $usePrefix)
+    {
+        $this->assertInstanceOf(IndexName::class, IndexName::createFromLocal($indexName, $usePrefix));
+    }
+
+    public function createReplicaDataProvider()
+    {
+        return [
+            ['posts_newest', true],
+            ['posts_newest', false],
+        ];
+    }
+
+    /**
+     * @dataProvider localDataProvider
+     */
+    public function testLocal($factoryMethod, $indexName, $usePrefix, $expected)
+    {
+        $sut = IndexName::{$factoryMethod}($indexName, $usePrefix);
+
+        $this->assertEquals($expected, $sut->local());
+    }
+
+    public function localDataProvider()
+    {
+        return [
+            ['createFromRemote', 'posts', true, 'posts'],
+            ['createFromRemote', 'posts', false, 'posts'],
+            ['createFromRemote', 'testing_posts', true, 'testing_posts'],
+            ['createFromRemote', 'testing_posts', false, 'posts'],
+            ['createFromLocal', 'posts_newest', true, 'testing_posts_newest'],
+            ['createFromLocal', 'posts_newest', false, 'posts_newest'],
+            ['createFromLocal', 'some Completely different index name', true, 'testing_some Completely different index name'],
+            ['createFromLocal', 'some Completely different index name', false, 'some Completely different index name'],
+        ];
+    }
+
+    /**
+     * @dataProvider remoteDataProvider
+     */
+    public function testRemote($factoryMethod, $indexName, $usePrefix, $expected)
+    {
+        $sut = IndexName::{$factoryMethod}($indexName, $usePrefix);
+
+        $this->assertEquals($expected, $sut->remote());
+    }
+
+    public function remoteDataProvider()
+    {
+        return [
+            ['createFromRemote', 'posts', true, 'posts'],
+            ['createFromRemote', 'posts', false, 'posts'],
+            ['createFromRemote', 'testing_posts', true, 'testing_posts'],
+            ['createFromRemote', 'testing_posts', false, 'testing_posts'],
+            ['createFromLocal', 'posts_newest', true, 'testing_posts_newest'],
+            ['createFromLocal', 'posts_newest', false, 'testing_posts_newest'],
+            ['createFromLocal', 'some Completely different index name', true, 'testing_some Completely different index name'],
+            ['createFromLocal', 'some Completely different index name', false, 'testing_some Completely different index name'],
+        ];
+    }
+
+    /**
+     * @dataProvider usesPrefixDataProvider
+     */
+    public function testUsesPrefix($indexName, $usePrefix, $assertMethod)
+    {
+        $sut = IndexName::createFromRemote($indexName, $usePrefix);
+
+        $this->{$assertMethod}($sut->usesPrefix());
+    }
+
+    public function usesPrefixDataProvider()
+    {
+        return [
+            ['posts', true, 'assertTrue'],
+            ['posts', false, 'assertFalse'],
+        ];
+    }
+}

--- a/tests/Algolia/Settings/IndexResourceRepositoryTest.php
+++ b/tests/Algolia/Settings/IndexResourceRepositoryTest.php
@@ -3,10 +3,8 @@
 namespace Algolia\Settings\Tests\Algolia\Settings;
 
 use Algolia\Settings\IndexResourceRepository;
-use Algolia\Settings\Tests\TestModel;
 use Algolia\Settings\Tests\TestModelWithSearchableTrait;
-use Laravel\Scout\Searchable;
-use Orchestra\Testbench\TestCase;
+use Algolia\Settings\Tests\TestCase;
 use org\bovigo\vfs\vfsStream;
 
 final class IndexResourceRepositoryTest extends TestCase
@@ -30,35 +28,65 @@ final class IndexResourceRepositoryTest extends TestCase
         "title"
     ],
     "replicas": [
-        "posts_newest",
-        "posts_oldest"
+        "testing_posts_newest",
+        "testing_posts_oldest"
     ],
     "customRanking": null
 }
 POST
                     ,
-                    'posts_newest' => <<<'POST'
+                    'posts_newest.json' => <<<'POST'
 {
     "searchableAttributes": [
         "title"
     ],
-    "primary": "posts",
+    "primary": "testing_posts",
     "customRanking": [
         "desc(published_at)"
     ]
 }
 POST
                     ,
-                    'posts_oldest' => <<<'POST'
+                    'posts_oldest.json' => <<<'POST'
 {
     "searchableAttributes": [
         "title"
     ],
-    "primary": "posts",
+    "primary": "testing_posts",
     "customRanking": [
         "asc(published_at)"
     ]
 }
+POST
+                    ,
+                    'posts-rules.json' => <<<'POST'
+[
+    {
+        "objectID"    : "a-rule-id",
+        "condition"   : {
+            "pattern"   : "smartphone",
+            "anchoring" : "contains"
+        },
+        "consequence" : {
+            "params" : {
+                "filters" : "category = 1"
+            }
+        }
+    }
+]
+POST
+                    ,'posts-synonyms.json' => <<<'POST'
+[
+   {
+      "objectID":"a-unique-identifier",
+      "type":"synonym",
+      "synonyms":[
+         "car",
+         "vehicle",
+         "auto"
+      ]
+   }
+]
 POST
                     ,
                 ],
@@ -98,29 +126,48 @@ POST
 
     public function testGetSettingsCustomLocation()
     {
-        $org_env = env('ALGOLIA_SETTINGS_FOLDER');
-        if ($org_env === null) {
-            // Currently not set. `putenv('SOME_KEY')`, so without equals sign,
-            // will actually unset the env variable.
-            $org_env = 'ALGOLIA_SETTINGS_FOLDER';
-        } else {
-            $org_env = 'ALGOLIA_SETTINGS_FOLDER=' . $org_env;
-        }
-        putenv('ALGOLIA_SETTINGS_FOLDER=custom-sub-path-settings/');
+        try {
+            $org_envs = $this->replaceEnvs(['ALGOLIA_SETTINGS_FOLDER' => 'custom-sub-path-settings/']);
 
+            $sut = new IndexResourceRepository();
+
+            $expected = [
+                'title',
+                'summary',
+            ];
+
+            $postSettings = $sut->getSettings((new TestModelWithSearchableTrait)->searchableAs());
+            $actual = $postSettings['searchableAttributes'];
+
+            $this->assertEquals($expected, $actual);
+        } finally {
+            $this->restoreEnvs($org_envs);
+        }
+    }
+
+    public function testGetSettingsUnknownIndex()
+    {
         $sut = new IndexResourceRepository();
 
-        $expected = [
-            'title',
-            'summary',
-        ];
+        $actual = $sut->getSettings('foobar');
 
-        $postSettings = $sut->getSettings((new TestModelWithSearchableTrait)->searchableAs());
-        $actual = $postSettings['searchableAttributes'];
+        $this->assertEquals([], $actual);
+    }
 
-        $this->assertEquals($expected, $actual);
+    public function testCreationSettingsDirectory()
+    {
+        try {
+            $org_envs = $this->replaceEnvs(['ALGOLIA_SETTINGS_FOLDER' => 'non-existing-directory/']);
 
-        putenv($org_env);
+            $this->assertFalse($this->file_system->hasChild('resources/non-existing-directory'));
+
+            new IndexResourceRepository();
+
+            $this->assertTrue($this->file_system->hasChild('resources/non-existing-directory'));
+
+        } finally {
+            $this->restoreEnvs($org_envs);
+        }
     }
 
     public function testSaveSettings()
@@ -132,8 +179,8 @@ POST
                 'tags',
             ],
             'replicas'             => [
-                'posts_newest',
-                'posts_oldest',
+                'testing_posts_newest',
+                'testing_posts_oldest',
             ],
             'customRanking'        => null,
         ];
@@ -148,5 +195,126 @@ POST
             $expected,
             $this->file_system->getChild('resources/algolia-settings/posts.json')->getContent()
         );
+    }
+
+    public function testGetRules()
+    {
+        $sut = new IndexResourceRepository();
+
+        $expected = [
+            [
+                'objectID'    => 'a-rule-id',
+                'condition'   => [
+                    'pattern'   => 'smartphone',
+                    'anchoring' => 'contains'
+                ],
+                'consequence' => [
+                    'params' => [
+                        'filters' => 'category = 1',
+                    ],
+                ],
+            ],
+        ];
+
+        $actual = $sut->getRules((new TestModelWithSearchableTrait)->searchableAs());
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testSaveRules()
+    {
+        $rules = [
+            [
+                'objectID'    => 'a-better-rule-id',
+                'condition'   => [
+                    'pattern'   => 'tablets',
+                    'anchoring' => 'contains'
+                ],
+                'consequence' => [
+                    'params' => [
+                        'filters' => 'category = 2',
+                    ],
+                ],
+            ],
+        ];
+
+        $sut = new IndexResourceRepository();
+
+        $actual = $sut->saveRules((new TestModelWithSearchableTrait)->searchableAs(), $rules);
+        $expected = \json_encode($rules);
+
+        $this->assertNotFalse($actual);
+        $this->assertJsonStringEqualsJsonString(
+            $expected,
+            $this->file_system->getChild('resources/algolia-settings/posts-rules.json')->getContent()
+        );
+    }
+
+    public function testSaveSynonyms()
+    {
+        $synonyms = [
+            [
+                'objectID' => 'a-unique-identifier',
+                'type'     => 'synonym',
+                'synonyms' => ['car', 'vehicle', 'auto'],
+            ],
+            [
+                'objectID' => 'another-unique-identifier',
+                'type'     => 'synonym',
+                'synonyms' => ['developer', 'programmer', 'software engineer'],
+            ],
+        ];
+
+        $sut = new IndexResourceRepository();
+
+        $actual = $sut->saveSynonyms((new TestModelWithSearchableTrait)->searchableAs(), $synonyms);
+        $expected = \json_encode($synonyms);
+
+        $this->assertNotFalse($actual);
+        $this->assertJsonStringEqualsJsonString(
+            $expected,
+            $this->file_system->getChild('resources/algolia-settings/posts-synonyms.json')->getContent()
+        );
+    }
+
+    public function testGetSynonyms()
+    {
+        $sut = new IndexResourceRepository();
+
+        $expected = [
+            [
+                'objectID' => 'a-unique-identifier',
+                'type'     => 'synonym',
+                'synonyms' => ['car', 'vehicle', 'auto'],
+            ],
+        ];
+
+        $actual = $sut->getSynonyms((new TestModelWithSearchableTrait)->searchableAs());
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * @dataProvider prefixOptionProvider
+     */
+    public function testUsePrefix($prefixOption, $expected)
+    {
+        $sut = new IndexResourceRepository();
+
+        $sut->usePrefix($prefixOption);
+
+        $reflected_property = new \ReflectionProperty(get_class($sut), 'usePrefix');
+        $reflected_property->setAccessible(true);
+        $actual = $reflected_property->getValue($sut);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function prefixOptionProvider()
+    {
+        return [
+            [true, true],
+            [false, false],
+        ];
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Algolia\Settings\Tests;
+
+use Orchestra\Testbench\TestCase as BaseTestCase;
+
+abstract class TestCase extends BaseTestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+
+        if (!config('scout.prefix')) {
+            config(['scout.prefix' => env('SCOUT_PREFIX', '')]);
+        }
+    }
+
+    /**
+     * @param array $envs
+     *
+     * @return array Original envs
+     */
+    protected function replaceEnvs(array $envs)
+    {
+        $org_envs = [];
+        foreach ($envs as $env => $value) {
+            $org_value = env($env);
+
+            if ($org_value === null) {
+                // Currently not set. `putenv('SOME_KEY')`, so without equals sign,
+                // will actually unset the env variable.
+                $org_envs[$env] = null;
+            } else {
+                $org_envs[$env] = $org_value;
+            }
+
+            if(null === $value) {
+                putenv($env);
+            } else {
+                putenv("{$env}={$value}");
+            }
+        }
+
+        return $org_envs;
+    }
+
+    /**
+     * @param array $envs
+     *
+     * @return array Original envs
+     */
+    protected function restoreEnvs(array $envs)
+    {
+        return $this->replaceEnvs($envs);
+    }
+}


### PR DESCRIPTION
Addresses most of the issue I tried to  describe in #23 , however this still hinges on the assumption that `searchableAs()` has the default behavior of prefixing the table name.