### PR TITLE
Corrects wording on saveRules console output

### DIFF
--- a/src/Console/BackupCommand.php
+++ b/src/Console/BackupCommand.php
@@ -118,8 +118,7 @@ final class BackupCommand extends AlgoliaCommand
         $success = $this->indexRepository->saveRules($indexName, $rules);
 
         if ($success) {
-            $this->line("Saved synonyms for $indexName");
-
+            $this->line("Saved query rules for $indexName");
         }
 
         return $success;


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Need Doc update   | no


## What was changed

Changes `Saved synonyms` output message to `Saved query rules` for saveRules()

## Why it was changed

When executing the `php artisan algolia:settings:backup Class`, the console output for saveRules() incorrect displays `Saved synonyms` :

> Saved settings for class
> All settings for [App\Class] index have been backed up.
> Saved synonyms for class
> All synonyms for [App\Class] index have been backed up.
> **Saved synonyms** for class
> All query rules for [App\Class] index have been backed up.

When it should actually read `Saved query rules`:

> **Saved query rules** for class
> All query rules for [App\Class] index have been backed up.

As this is just a change of a string, no functionality was changed.